### PR TITLE
Fixed incorrect repeat Quaternion parameter in Redout plugin

### DIFF
--- a/RedOutPlugin/RedoutPlugin.cs
+++ b/RedOutPlugin/RedoutPlugin.cs
@@ -83,7 +83,7 @@ namespace RedOutPlugin
             while (running) {
                 Packet p = ReadPacket();
 
-                Quaternion quater = new Quaternion(p.QuatX,p.QuatY,p.QuatZ,p.QuatZ);
+                Quaternion quater = new Quaternion(p.QuatX,p.QuatY,p.QuatZ,p.QuatW);
               
                 float roll = (float)RadianToDegree(quater.toYawFromYUp()) * -1;
                 float pitch = (float)RadianToDegree(quater.toPitchFromYUp()) * -1;


### PR DESCRIPTION
This small change makes it so t hat the Yaw values returned are correct and 1:1 with the orientation of the ship. Yaw is otherwise bugged out and will not behave correctly without this fix. 